### PR TITLE
Leave scala version open to interpretation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,4 +4,4 @@ version := "0.0.1"
 
 scalaVersion := "2.10.5"
 
-libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.2.1" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.1" % "test"


### PR DESCRIPTION
There's no need to specify `_2.10` in `libraryDependencies` if we use `%%` instead of `%` for the first separator - `%%` just fills in the right scala version based on `scalaVersion`.

After this change, flipping `scalaVersion` to 2.11.6 works great, leading me to https://github.com/Originate/scalypher/issues/5
