### PR TITLE
Update set query to take single varargs argument

### DIFF
--- a/src/main/scala/path/Path.scala
+++ b/src/main/scala/path/Path.scala
@@ -25,8 +25,8 @@ case class Path(start: Node, pieces: Seq[PathPiece] = Seq.empty) extends NonRefe
   def as(name: String): ActionItem =
     ActionPath(this, Some(name))
 
-  def set(assignment: Assignment, rest: Assignment*): SetQuery =
-    SetQuery(this, assignment, rest: _*)
+  def set(assignments: Assignment*): SetQuery =
+    SetQuery(this, assignments: _*)
 
   def create(createPath: Path): CreateQuery =
     CreateQuery(createPath, Seq(this))

--- a/src/main/scala/path/PathWithWhere.scala
+++ b/src/main/scala/path/PathWithWhere.scala
@@ -15,8 +15,8 @@ import com.originate.scalypher.where.Reference
 import com.originate.scalypher.where.Where
 
 case class PathWithWhere(path: Path, where: Option[Where]) {
-  def set(assignment: Assignment, rest: Assignment*): SetQuery =
-    SetQuery(path, where, assignment, rest: _*)
+  def set(assignments: Assignment*): SetQuery =
+    SetQuery(path, where, assignments: _*)
 
   def returns(reference: ActionItem, rest: ActionItem*): Query =
     MatchQuery(path, where, ReturnReference(reference, rest: _*))

--- a/src/main/scala/query/SetQuery.scala
+++ b/src/main/scala/query/SetQuery.scala
@@ -14,12 +14,9 @@ import com.originate.scalypher.where.Where
 case class SetQuery(
   pathMatch: Path,
   where: Option[Where],
-  assignment: Assignment,
-  rest: Seq[Assignment],
+  assignments: Seq[Assignment],
   action: Option[ReturnAction]
 ) extends Query {
-
-  private val assignments = assignment +: rest
 
   def returns(reference: ActionItem, rest: ActionItem*): Query =
     copy(action = Some(ReturnReference(reference, rest: _*)))
@@ -53,22 +50,21 @@ case class SetQuery(
 
 object SetQuery {
 
-  def apply(pathMatch: Path, assignment: Assignment, rest: Assignment*): SetQuery =
-    SetQuery(pathMatch, None, assignment, rest, None)
+  def apply(pathMatch: Path, assignments: Assignment*): SetQuery =
+    SetQuery(pathMatch, None, assignments, None)
 
-  def apply(pathMatch: Path, where: Where, assignment: Assignment, rest: Assignment*): SetQuery =
-    SetQuery(pathMatch, Some(where), assignment, rest, None)
+  def apply(pathMatch: Path, where: Where, assignments: Assignment*): SetQuery =
+    SetQuery(pathMatch, Some(where), assignments, None)
 
-  def apply(pathMatch: Path, where: Option[Where], assignment: Assignment, rest: Assignment*): SetQuery =
-    SetQuery(pathMatch, where, assignment, rest, None)
+  def apply(pathMatch: Path, where: Option[Where], assignments: Assignment*): SetQuery =
+    SetQuery(pathMatch, where, assignments, None)
 
   def apply(
     pathMatch: Path,
     where: Where,
     action: ReturnAction,
-    assignment: Assignment,
-    rest: Assignment*
+    assignments: Assignment*
   ): SetQuery =
-    SetQuery(pathMatch, Some(where), assignment, rest, Some(action))
+    SetQuery(pathMatch, Some(where), assignments, Some(action))
 
 }

--- a/src/test/scala/query/SetQuerySpec.scala
+++ b/src/test/scala/query/SetQuerySpec.scala
@@ -33,6 +33,15 @@ class SetQuerySpec extends WordSpec with Matchers {
       query.toQuery shouldBe """MATCH (a1)-->() SET a1.name = "x", a1.age = 2"""
     }
 
+    "allow setting multiple values passed as single varargs" in {
+      val setStatements = List(
+        startNode.property("name") := "z",
+        startNode.property("age") := 7
+      )
+      val query = path set (setStatements: _*)
+      query.toQuery shouldBe """MATCH (a1)-->() SET a1.name = "z", a1.age = 7"""
+    }
+
     "retain ordering when setting multiple values on the same property" in {
       val query = path set (
         startNode.property("name") := "x",


### PR DESCRIPTION
Previously, if you had a list of set assignments, it was not possible
to pass it as a single varargs. It had to be split into head and tail.

This update allows set query creation with only a single varargs parameter.

**Before:**

```scala
val setStatements: Seq[Assignment] = generateSetStatements(node, personObject)
path.set(setStatements.head, setStatements.tail: *)
```

**After:**

```scala
val setStatements: Seq[Assignment] = generateSetStatements(node, personObject)
path.set(setStatements: _*)
```

This also doesn't break backwards compatibility for simply listing out all of the set statements in the query:

```scala
path.set(
  node.property("name") := "Nick",
  node.property("age") := 2
)
```

But it does break backwards compatibility for the **Before** case.